### PR TITLE
corrected test for gpg extension in hg

### DIFF
--- a/lib/rubygems/tasks/scm/tag.rb
+++ b/lib/rubygems/tasks/scm/tag.rb
@@ -116,7 +116,7 @@ module Gem
                     when :git
                       !`git config user.signingkey`.chomp.empty?
                     when :hg
-                      !`hg showconfig extensions hgext gpg`.chomp.empty?
+                      !`hg showconfig extensions.hgext.gpg`.empty?
                     else
                       false
                     end


### PR DESCRIPTION
At least in mercurial 2.4.2 to check if gpg extension is installed one should do `hg showconfig extensions.hgext.gpg` and if it returns anything, but empty string, the extension is enabled. Even "\n" indicates that extension is turned on, so chomp is invalid.
