### PR TITLE
Add ostruct to dependencies

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -21,6 +21,7 @@ required_ruby_version: ">= 2.0.0"
 dependencies:
   rake: ">= 10.0.0"
   irb: ~> 1.0
+  ostruct: ~> 0.6
 
 development_dependencies:
   bundler: ~> 2.0


### PR DESCRIPTION
Hi,

ostruct will be promoted to bundled gem from Ruby 3.5:
https://github.com/ruby/ruby/blob/v3_5_0_preview1/NEWS.md

I added it to dependencies.

Thanks.