### PR TITLE
Allow bundler version 4

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -23,4 +23,4 @@ dependencies:
   irb: ~> 1.0
 
 development_dependencies:
-  bundler: ~> 2.0
+  bundler: ">= 2.0"


### PR DESCRIPTION
This pull request allows bundler version 4 that is installed with Ruby 3.5.0dev that includes https://github.com/ruby/ruby/commit/afe40df42331e338411c84714ca5d21383dac3d4

### Steps to reproduce
1. Install Ruby 3.5.0dev
2.  Follow these steps below
```
git clone https://github.com/postmodern/rubygems-tasks
cd rubygems-tasks
bundle install
```
### Expected behavior
It should install gems.

### Actual behavior without this fix
```ruby
$ ruby -v
ruby 3.5.0dev (2025-10-12T08:00:03Z master c938c11f10) +PRISM [x86_64-linux]
$ gem -v
4.0.0.dev
$ bundler -v
4.0.0.dev
$ bundle install
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Could not find compatible versions

Because the current Bundler version (4.0.0.dev) does not satisfy bundler ~> 2.0
  and Gemfile depends on bundler ~> 2.0,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.7.2` and rerun bundler using `bundle _2.7.2_ install`
$
```

###  With this fix
```
$ bundle install
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Bundle complete! 8 Gemfile dependencies, 27 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$
```
